### PR TITLE
Only set reuseport once per ip:port pair

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -222,9 +222,10 @@ export default (domains, global) => {
 
     // Single file configs
     if (!global.tools.modularizedStructure.computed) {
+        const ipPortPairs = new Set();
         for (const domain of domains) {
             config.http.push([`# ${domain.server.domain.computed}`, '']);
-            config.http.push(...websiteConf(domain, domains, global));
+            config.http.push(...websiteConf(domain, domains, global, ipPortPairs));
         }
     }
 

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -56,56 +56,75 @@ const sslConfig = (domain, global) => {
     return config;
 };
 
-const httpsListen = (domain, global) => {
+const httpsListen = (domain, global, ipPortPairs) => {
     const config = [];
+
+    // Check if reuseport needs to be set
+    const ipPortV4 = `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443`;
+    const reusePortV4 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV4);
+    if (reusePortV4) ipPortPairs.add(ipPortV4);
 
     // HTTPS
     config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
+        `${ipPortV4} ssl${domain.https.http2.computed ? ' http2' : ''}${reusePortV4 ? ' reuseport' : ''}`]);
 
     // HTTP/3
     if (domain.https.http3.computed)
-        config.push(['listen',
-            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3`]);
+        config.push(['listen', `${ipPortV4} http3`]);
 
     // v6
-    if (domain.server.listenIpv6.computed)
-        config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
+    if (domain.server.listenIpv6.computed) {
+        // Check if reuseport needs to be set
+        const ipPortV6 = `[${domain.server.listenIpv6.computed}]:443`;
+        const reusePortV6 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV6);
+        if (reusePortV6) ipPortPairs.add(ipPortV6);
 
-    // v6 HTTP/3
-    if (domain.server.listenIpv6.computed && domain.https.http3.computed)
+        // HTTPS
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 http3`]);
+            `${ipPortV6} ssl${domain.https.http2.computed ? ' http2' : ''}${reusePortV6 ? ' reuseport' : ''}`]);
+
+        // HTTP/3
+        if (domain.https.http3.computed)
+            config.push(['listen', `${ipPortV6} http3`]);
+    }
 
     return config;
 };
 
-const httpListen = domain => {
+const httpListen = (domain, global, ipPortPairs) => {
     const config = [];
 
-    // Not HTTPS
-    config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`]);
+    // Check if reuseport needs to be set
+    const ipPortV4 = `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`;
+    const reusePortV4 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV4);
+    if (reusePortV4) ipPortPairs.add(ipPortV4);
+
+    // v4
+    config.push(['listen', `${ipPortV4}${reusePortV4 ? ' reuseport' : ''}`]);
 
     // v6
-    if (domain.server.listenIpv6.computed)
-        config.push(['listen', `[${domain.server.listenIpv6.computed}]:80`]);
+    if (domain.server.listenIpv6.computed) {
+        // Check if reuseport needs to be set
+        const ipPortV6 = `[${domain.server.listenIpv6.computed}]:80`;
+        const reusePortV6 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV6);
+        if (reusePortV6) ipPortPairs.add(ipPortV6);
+
+        config.push(['listen', `${ipPortV6}${reusePortV6 ? ' reuseport' : ''}`]);
+    }
 
     return config;
 };
 
-const listenConfig = (domain, global) => {
-    if (domain.https.https.computed) return httpsListen(domain, global);
-    return httpListen(domain);
+const listenConfig = (domain, global, ipPortPairs) => {
+    if (domain.https.https.computed) return httpsListen(domain, global, ipPortPairs);
+    return httpListen(domain, global, ipPortPairs);
 };
 
-
-const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
+const httpRedirectConfig = (domain, global, ipPortPairs, domainName, redirectDomain) => {
     // Build the server config on its own before adding it to the parent config
     const config = [];
 
-    config.push(...httpListen(domain));
+    config.push(...httpListen(domain, global, ipPortPairs));
     config.push(['server_name', domainName]);
 
     if (domain.https.certType.computed === 'letsEncrypt') {
@@ -130,7 +149,7 @@ const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
     return config;
 };
 
-export default (domain, domains, global) => {
+export default (domain, domains, global, ipPortPairs) => {
     // Use kv so we can use the same key multiple times
     const config = [];
 
@@ -138,10 +157,12 @@ export default (domain, domains, global) => {
     const serverConfig = [];
 
     // Not HTTPS or not force HTTPS
-    if (!domain.https.https.computed || !domain.https.forceHttps.computed) serverConfig.push(...httpListen(domain));
+    if (!domain.https.https.computed || !domain.https.forceHttps.computed)
+        serverConfig.push(...httpListen(domain, global, ipPortPairs));
 
     // HTTPS
-    if (domain.https.https.computed) serverConfig.push(...httpsListen(domain, global));
+    if (domain.https.https.computed)
+        serverConfig.push(...httpsListen(domain, global, ipPortPairs));
 
     serverConfig.push(['server_name',
         `${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}`]);
@@ -340,7 +361,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const cdnConfig = [];
 
-        cdnConfig.push(...listenConfig(domain, global));
+        cdnConfig.push(...listenConfig(domain, global, ipPortPairs));
         cdnConfig.push(['server_name', `cdn.${domain.server.domain.computed}`]);
         cdnConfig.push(['root', `${domain.server.path.computed}${domain.server.documentRoot.computed}`]);
 
@@ -383,7 +404,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const redirectConfig = [];
 
-        redirectConfig.push(...listenConfig(domain, global));
+        redirectConfig.push(...listenConfig(domain, global, ipPortPairs));
         redirectConfig.push(['server_name',
             `${domain.server.wwwSubdomain.computed ? '' : '*'}.${domain.server.domain.computed}`]);
 
@@ -403,17 +424,21 @@ export default (domain, domains, global) => {
         // Add the redirect config to the parent config now its built
         config.push(['# HTTP redirect', '']);
         if (domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed,
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                domain.server.domain.computed, `www.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
                 `www.${domain.server.domain.computed}`)]);
-            config.push(['server', httpRedirectConfig(domain, global, `www.${domain.server.domain.computed}`)]);
         } else if (!domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                domain.server.domain.computed)]);
         }
         if (domain.server.cdnSubdomain.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, `cdn.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                `cdn.${domain.server.domain.computed}`)]);
         }
         if (domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, `.${domain.server.domain.computed}`,
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                `.${domain.server.domain.computed}`,
                 `${domain.server.wwwSubdomain.computed ? 'www.' : '' }${domain.server.domain.computed}`)]);
         }
     }

--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -57,8 +57,10 @@ export default (domains, global) => {
     // Modularised configs
     if (global.tools.modularizedStructure.computed) {
         // Domain config
+        const sitesDir = `sites-${global.tools.symlinkVhost.computed ? 'available' : 'enabled'}`;
+        const ipPortPairs = new Set();
         for (const domain of domains) {
-            files[`sites-${global.tools.symlinkVhost.computed ? 'available' : 'enabled'}/${domain.server.domain.computed}.conf`] = toConf(websiteConf(domain, domains, global));
+            files[`${sitesDir}/${domain.server.domain.computed}.conf`] = toConf(websiteConf(domain, domains, global, ipPortPairs));
         }
 
         // Let's encrypt

--- a/src/nginxconfig/i18n/en/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/templates/global_sections/https.vue
+++ b/src/nginxconfig/templates/global_sections/https.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,24 @@ THE SOFTWARE.
 
 <template>
     <div>
+        <div class="field is-horizontal">
+            <div class="field-label">
+                <label class="label">{{ $t('templates.globalSections.https.portReuse') }}</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
+                        <div class="checkbox">
+                            <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
+                                <i slot="extra" class="icon fas fa-check"></i>
+                                {{ $t('templates.globalSections.https.enableReuseOfPort') }}
+                            </PrettyCheck>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div v-if="!sslProfileEnabled" class="field is-horizontal is-aligned-top">
             <div class="field-label">
                 <label class="label">{{ $t('templates.globalSections.https.sslProfile') }}</label>
@@ -58,24 +76,6 @@ THE SOFTWARE.
                                         {{ $t(name) }}
                                     </PrettyRadio>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="field is-horizontal is-aligned-top">
-                <div class="field-label">
-                    <label class="label">{{ $t('templates.globalSections.https.portReuse') }}</label>
-                </div>
-                <div class="field-body">
-                    <div class="field">
-                        <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
-                            <div class="checkbox">
-                                <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
-                                    <i slot="extra" class="icon fas fa-check"></i>
-                                    {{ $t('templates.globalSections.https.enableReuseOfPort') }}
-                                </PrettyCheck>
                             </div>
                         </div>
                     </div>
@@ -257,6 +257,10 @@ THE SOFTWARE.
     };
 
     const defaults = {
+        portReuse: {
+            default: false,
+            enabled: true,
+        },
         sslProfile: {
             default: 'intermediate',
             options: {
@@ -264,10 +268,6 @@ THE SOFTWARE.
                 intermediate: 'templates.globalSections.https.mozillaIntermediate', // i18n key
                 old: 'templates.globalSections.https.mozillaOld', // i18n key
             },
-            enabled: true,
-        },
-        portReuse: {
-            default: false,
             enabled: true,
         },
         ocspCloudflare: {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Conf generators, https global section, i18n files

## What issue does this relate to?

cc https://github.com/digitalocean/nginxconfig.io/pull/283

### What should this PR do?

Ensures that we only set the `reuseport` directive once per IP:port pair.

Also, moves the `reuseport` toggle outside the SSL conditional in the global https section.

### What are the acceptance criteria?

With `reuseport` enabled, and more than one site configured in the tool, the resulting config is valid and passes `nginx -t`.